### PR TITLE
Register CC config values with config conditions

### DIFF
--- a/src/main/java/com/minecraftabnormals/caverns_and_chasms/core/CCConfig.java
+++ b/src/main/java/com/minecraftabnormals/caverns_and_chasms/core/CCConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.caverns_and_chasms.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import org.apache.commons.lang3.tuple.Pair;
@@ -7,13 +8,25 @@ import org.apache.commons.lang3.tuple.Pair;
 public class CCConfig {
 
 	public static class Common {
+
+		@ConfigKey("creeper_explosions_destroy_blocks")
 		public final ConfigValue<Boolean> creeperExplosionsDestroyBlocks;
+
+		@ConfigKey("deeper_max_spawn_height")
 		public final ConfigValue<Integer> deeperMaxSpawnHeight;
+
+		@ConfigKey("large_emerald_veins_enabled")
 		public final ConfigValue<Boolean> largeEmeraldVeins;
 
+
+		@ConfigKey("chainmail_armor_buff_enabled")
 		public final ConfigValue<Boolean> chainmailArmorBuff;
 
+
+		@ConfigKey("better_rail_placement_enabled")
 		public final ConfigValue<Boolean> betterRailPlacement;
+
+		@ConfigKey("better_rail_placement_range")
 		public final ConfigValue<Integer> betterRailPlacementRange;
 
 		public Common(ForgeConfigSpec.Builder builder) {

--- a/src/main/java/com/minecraftabnormals/caverns_and_chasms/core/CavernsAndChasms.java
+++ b/src/main/java/com/minecraftabnormals/caverns_and_chasms/core/CavernsAndChasms.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.caverns_and_chasms.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.caverns_and_chasms.client.DeeperSpriteUploader;
 import com.minecraftabnormals.caverns_and_chasms.client.render.layer.UndeadParrotLayer;
@@ -37,6 +38,7 @@ public class CavernsAndChasms {
 		CCRecipes.Serailizers.RECIPE_SERIALIZERS.register(bus);
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CCConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(CavernsAndChasms.MOD_ID, CCConfig.COMMON);
 
 		bus.addListener(this::commonSetup);
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.